### PR TITLE
Fix French date localization: translate month names and use day-month-year format

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -23,6 +23,43 @@ newsletter:
   cta:
     en: Subscribe
     fr: S'abonner
+months:
+  "Jan":
+    en: "Jan"
+    fr: "janv."
+  "Feb":
+    en: "Feb"
+    fr: "févr."
+  "Mar":
+    en: "Mar"
+    fr: "mars"
+  "Apr":
+    en: "Apr"
+    fr: "avr."
+  "May":
+    en: "May"
+    fr: "mai"
+  "Jun":
+    en: "Jun"
+    fr: "juin"
+  "Jul":
+    en: "Jul"
+    fr: "juil."
+  "Aug":
+    en: "Aug"
+    fr: "août"
+  "Sep":
+    en: "Sep"
+    fr: "sept."
+  "Oct":
+    en: "Oct"
+    fr: "oct."
+  "Nov":
+    en: "Nov"
+    fr: "nov."
+  "Dec":
+    en: "Dec"
+    fr: "déc."
 footer:
   subscribe:
     title: 

--- a/_includes/home.html
+++ b/_includes/home.html
@@ -57,7 +57,7 @@
                 <a class="home-simple-post" href="{{ post.url | prepend: site.baseurl }}">
               {% endif %}
                 <div class="home-simple-post-date">
-                  {{ post.date | date: "%b %-d, %Y" }}
+                  {% include localized-date.html date=post.date language=page.language %}
                 </div>
                 <h3 class="home-simple-post-title">
                   {{ post.title }}

--- a/_includes/localized-date.html
+++ b/_includes/localized-date.html
@@ -1,0 +1,1 @@
+{% assign m = include.date | date: "%b" %}{% assign d = include.date | date: "%-d" %}{% assign y = include.date | date: "%Y" %}{% assign lang = include.language %}{% assign month = site.data.translations.months[m][lang] %}{% if lang == "fr" %}{{ d }} {{ month }} {{ y }}{% else %}{{ month }} {{ d }}, {{ y }}{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
 
     <header class="post-header">
       <h1 class="post-title">{{ page.title }}</h1>
-      <p class="post-meta">{{ page.date | date: "%b %-d, %Y" }}{% if page.author %} • {{ page.author }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
+      <p class="post-meta">{% include localized-date.html date=page.date language=page.language %}{% if page.author %} • {{ page.author }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
     </header>
 
     <article class="post-content">

--- a/en/archive.md
+++ b/en/archive.md
@@ -9,5 +9,5 @@ permalink: /en/archive
 {% assign siteposts = site.posts | where: 'language', page.language %}
 
 {% for post in siteposts %}
-- **{{ post.date | date: "%b %-d, %Y" }}** — [{{ post.title }}]({{ post.url | prepend: site.baseurl }}){% if post.external_url %} <span class="icon icon-external-link"></span>{% endif %}
+- **{% include localized-date.html date=post.date language=page.language %}** — [{{ post.title }}]({{ post.url | prepend: site.baseurl }}){% if post.external_url %} <span class="icon icon-external-link"></span>{% endif %}
 {% endfor %}

--- a/fr/archive.md
+++ b/fr/archive.md
@@ -9,5 +9,5 @@ permalink: /fr/archive
 {% assign siteposts = site.posts | where: 'language', page.language %}
 
 {% for post in siteposts %}
-- **{{ post.date | date: "%b %-d, %Y" }}** — [{{ post.title }}]({{ post.url | prepend: site.baseurl }}){% if post.external_url %} <span class="icon icon-external-link"></span>{% endif %}
+- **{% include localized-date.html date=post.date language=page.language %}** — [{{ post.title }}]({{ post.url | prepend: site.baseurl }}){% if post.external_url %} <span class="icon icon-external-link"></span>{% endif %}
 {% endfor %}


### PR DESCRIPTION
Dates were always displayed in English (e.g., "Mar 12, 2015") even on French
pages. Added French month translations to translations.yml and a reusable
localized-date.html include that renders dates in the correct format per
language: "12 mars 2015" for French, "Mar 12, 2015" for English.

https://claude.ai/code/session_014YkgsCFZcgTaQLu7jAwB3w