### PR TITLE
Add sitemap.xml support with footer link

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -68,6 +68,9 @@ footer:
     rss:
       en: subscribe
       fr: s'abonner
+    sitemap:
+      en: Sitemap
+      fr: Plan du site
   follow:
     title:
       en: Follow

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,6 +15,7 @@
         <ul class="contact-list">
           <li><b>{{ translations.footer.subscribe.title[page.language] }}</b></li>
           <li class="rss-subscribe">{{ translations.footer.subscribe.rss[page.language] }} <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></li>
+          <li><a href="{{ "/sitemap.xml" | prepend: site.baseurl }}">{{ translations.footer.subscribe.sitemap[page.language] }}</a></li>
           <!-- <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li> -->
         </ul>
       </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,18 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for page in site.pages %}{% if page.layout and page.url != '/sitemap.xml' and page.url != '/feed.xml' and page.url != '/search-index.json' %}
+  <url>
+    <loc>{{ page.url | prepend: site.baseurl | prepend: site.url }}</loc>
+    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+  </url>
+  {% endif %}{% endfor %}
+  {% for post in site.posts %}{% unless post.archived %}
+  <url>
+    <loc>{{ post.url | prepend: site.baseurl | prepend: site.url }}</loc>
+    <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+  </url>
+  {% endunless %}{% endfor %}
+</urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,17 +2,55 @@
 layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {% for page in site.pages %}{% if page.layout and page.url != '/sitemap.xml' and page.url != '/feed.xml' and page.url != '/search-index.json' %}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+{%- for page in site.pages -%}
+  {%- if page.layout and page.url != '/sitemap.xml' and page.url != '/feed.xml' and page.url != '/search-index.json' %}
   <url>
     <loc>{{ page.url | prepend: site.baseurl | prepend: site.url }}</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+    {%- if page.language -%}
+      {%- if page.url == '/' -%}
+        {%- assign alt_url = '/fr/home.html' -%}
+        {%- assign alt_page = site.pages | where: "url", alt_url -%}
+        {%- if alt_page.size > 0 %}
+    <xhtml:link rel="alternate" hreflang="x-default" href="{{ page.url | prepend: site.baseurl | prepend: site.url }}" />
+    <xhtml:link rel="alternate" hreflang="en" href="{{ page.url | prepend: site.baseurl | prepend: site.url }}" />
+    <xhtml:link rel="alternate" hreflang="fr" href="{{ alt_url | prepend: site.baseurl | prepend: site.url }}" />
+        {%- endif -%}
+      {%- else -%}
+        {%- if page.language == 'en' -%}
+          {%- assign alt_lang = 'fr' -%}
+          {%- assign alt_url = page.url | replace_first: '/en/', '/fr/' -%}
+        {%- elsif page.language == 'fr' -%}
+          {%- assign alt_lang = 'en' -%}
+          {%- assign alt_url = page.url | replace_first: '/fr/', '/en/' -%}
+        {%- endif -%}
+        {%- if alt_url != page.url -%}
+          {%- assign alt_page = site.pages | where: "url", alt_url -%}
+          {%- if alt_page.size > 0 %}
+    <xhtml:link rel="alternate" hreflang="{{ page.language }}" href="{{ page.url | prepend: site.baseurl | prepend: site.url }}" />
+    <xhtml:link rel="alternate" hreflang="{{ alt_lang }}" href="{{ alt_url | prepend: site.baseurl | prepend: site.url }}" />
+          {%- endif -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endif %}
   </url>
-  {% endif %}{% endfor %}
-  {% for post in site.posts %}{% unless post.archived %}
+  {%- endif -%}
+{%- endfor -%}
+{%- for post in site.posts -%}
+  {%- unless post.archived %}
   <url>
     <loc>{{ post.url | prepend: site.baseurl | prepend: site.url }}</loc>
     <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+    {%- assign same_slug_posts = site.posts | where: "slug", post.slug -%}
+    {%- assign alt_posts = same_slug_posts | where_exp: "p", "p.language != post.language and p.archived != true" -%}
+    {%- if alt_posts.size > 0 -%}
+      {%- assign alt_post = alt_posts[0] %}
+    <xhtml:link rel="alternate" hreflang="{{ post.language }}" href="{{ post.url | prepend: site.baseurl | prepend: site.url }}" />
+    <xhtml:link rel="alternate" hreflang="{{ alt_post.language }}" href="{{ alt_post.url | prepend: site.baseurl | prepend: site.url }}" />
+    {%- endif %}
   </url>
-  {% endunless %}{% endfor %}
+  {%- endunless -%}
+{%- endfor %}
 </urlset>


### PR DESCRIPTION
## Summary
This PR adds XML sitemap support to the Jekyll site, enabling better search engine discoverability and crawlability.

## Key Changes
- **New sitemap.xml file**: Created a Jekyll-generated XML sitemap that includes all pages (excluding special files like feed.xml and search-index.json) and all non-archived posts with proper lastmod timestamps
- **Footer link**: Added a bilingual sitemap link in the footer's subscribe section, with translations for both English ("Sitemap") and French ("Plan du site")
- **Translation support**: Extended the translations.yml file with sitemap link labels for both supported languages

## Implementation Details
- The sitemap uses Jekyll's Liquid templating to dynamically generate URL entries from `site.pages` and `site.posts`
- Pages are filtered to exclude layout-less pages and special files (sitemap.xml, feed.xml, search-index.json)
- Posts are filtered to exclude archived content using the `archived` flag
- Each entry includes the full URL (with baseurl and site URL prepended) and appropriate lastmod date (site.time for pages, post.date for posts)
- The sitemap follows the standard XML sitemap protocol (http://www.sitemaps.org/schemas/sitemap/0.9)

https://claude.ai/code/session_01P1WRUWnK4VZmCQjWsCTtoY