### PR TITLE
Add draft status support for posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,25 @@ posts:
 
 ## Multilingual posts
 
+# Draft Posts
+
+Posts can be marked as drafts by adding `draft: true` to the front matter:
+
+```yaml
+---
+title: "My Post"
+draft: true
+---
+```
+
+When a post is marked as draft:
+
+- A **"DRAFT" banner** is displayed at the top of the post page
+- A `<meta name="robots" content="noindex, nofollow">` tag is added to prevent search engine indexing
+- The post is **excluded** from the sitemap, RSS feed, home page, and archive listings
+
+To publish, simply remove `draft: true` from the front matter. The post will immediately appear in all listings and become indexable by search engines.
+
 # Conventions
 
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,7 @@
 
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  {% if page.draft %}<meta name="robots" content="noindex, nofollow">{% endif %}
 
   <link rel="icon" type="image/png" href="/assets/icons/favicon.png" />
   <meta name="theme-color" content="#ffffff" />

--- a/_includes/home.html
+++ b/_includes/home.html
@@ -1,5 +1,5 @@
 {% assign translations = site.data.translations %}
-{% assign siteposts = site.posts | where: 'language', page.language | where_exp: 'post', 'post.archived != true' %}
+{% assign siteposts = site.posts | where: 'language', page.language | where_exp: 'post', 'post.archived != true' | where_exp: 'post', 'post.draft != true' %}
 
 <div class="page-wrapper">
   <div class="home">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,6 +4,9 @@ layout: default
 <div class="wrapper">
   <div class="post">
 
+    {% if page.draft %}
+    <div class="draft-banner" style="background: #f0ad4e; color: #fff; text-align: center; padding: 8px; font-weight: bold; border-radius: 4px; margin-bottom: 16px;">DRAFT</div>
+    {% endif %}
     <header class="post-header">
       <h1 class="post-title">{{ page.title }}</h1>
       <p class="post-meta">{% include localized-date.html date=page.date language=page.language %}{% if page.author %} • {{ page.author }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>

--- a/en/archive.md
+++ b/en/archive.md
@@ -6,7 +6,7 @@ permalink: /en/archive
 ---
 
 {% assign translations = site.data.translations %}
-{% assign siteposts = site.posts | where: 'language', page.language %}
+{% assign siteposts = site.posts | where: 'language', page.language | where_exp: 'post', 'post.draft != true' %}
 
 {% for post in siteposts %}
 - **{% include localized-date.html date=post.date language=page.language %}** — [{{ post.title }}]({{ post.url | prepend: site.baseurl }}){% if post.external_url %} <span class="icon icon-external-link"></span>{% endif %}

--- a/feed.xml
+++ b/feed.xml
@@ -11,7 +11,8 @@ layout: null
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
-    {% for post in site.posts limit:10 %}
+    {% assign feedposts = site.posts | where_exp: 'post', 'post.draft != true' %}
+    {% for post in feedposts limit:10 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>

--- a/fr/archive.md
+++ b/fr/archive.md
@@ -6,7 +6,7 @@ permalink: /fr/archive
 ---
 
 {% assign translations = site.data.translations %}
-{% assign siteposts = site.posts | where: 'language', page.language %}
+{% assign siteposts = site.posts | where: 'language', page.language | where_exp: 'post', 'post.draft != true' %}
 
 {% for post in siteposts %}
 - **{% include localized-date.html date=post.date language=page.language %}** — [{{ post.title }}]({{ post.url | prepend: site.baseurl }}){% if post.external_url %} <span class="icon icon-external-link"></span>{% endif %}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -41,7 +41,7 @@ layout: null
   {%- endif -%}
 {%- endfor -%}
 {%- for post in site.posts -%}
-  {%- unless post.archived %}
+  {%- unless post.archived or post.draft %}
   <url>
     <loc>{{ post.url | prepend: site.baseurl | prepend: site.url }}</loc>
     <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>


### PR DESCRIPTION
Posts with `draft: true` in front matter are now excluded from the
home page, archive pages, RSS feed, and sitemap. A visible DRAFT
banner is shown when viewing a draft post directly.

https://claude.ai/code/session_01WtoX5Jz4GBEUqMva8edxHt